### PR TITLE
Keeper

### DIFF
--- a/contracts/FarmTreasury.sol
+++ b/contracts/FarmTreasury.sol
@@ -18,4 +18,9 @@ contract FarmTreasury is Context, Ownable  {
     }
 
     receive() external payable {}
+
+    function doBuyBack() public {
+
+    }
+
 }

--- a/contracts/FarmTreasury.sol
+++ b/contracts/FarmTreasury.sol
@@ -23,4 +23,8 @@ contract FarmTreasury is Context, Ownable  {
 
     }
 
+    function addAccruedInterestToBuyBackPool() public {
+
+    }
+
 }

--- a/contracts/MarketTrend.sol
+++ b/contracts/MarketTrend.sol
@@ -199,9 +199,9 @@ contract MarketTrend is Ownable, KeeperCompatibleInterface {
         lastBuyBackChance = buyBackChance;
         lastBuyBackChoice = buyBackRandomNumber;
 
-        if (buyBackRandomNumber < buyBackChance) {
+        if (block.timestamp >= baseTrackingPeriodEnd && _isNegativeOrZeroPriceChange && buyBackRandomNumber < buyBackChance) {
             isBuyBackNeeded = true;
-        } else {
+        } else if (block.timestamp >= baseTrackingPeriodEnd && _isNegativeOrZeroPriceChange) {
             buyBackChance = buyBackChance + buyBackChanceIncrement;
         }
 

--- a/contracts/MarketTrendKeeperHelper.sol
+++ b/contracts/MarketTrendKeeperHelper.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity ^0.8.0;
+
+
+contract MarketTrendKeeperHelper {
+
+    function upkeepNeeded(uint lastTimeStamp, uint interval) public view returns (bool) {
+        return (block.timestamp - lastTimeStamp) > interval;
+    }
+
+}

--- a/deploy/0001_deploy_tufftoken.js
+++ b/deploy/0001_deploy_tufftoken.js
@@ -51,6 +51,14 @@ module.exports = async () => {
     log: true,
   });
 
+  const marketTrendKeeperHelper = await deploy('MarketTrendKeeperHelper', {
+    from: deployer,
+    args: [
+    ],
+    log: true,
+  });
+
+
   transactionCount = await deployerAcct.getTransactionCount();
 
   const marketTrendAddress = getContractAddress({
@@ -87,7 +95,9 @@ module.exports = async () => {
     args: [
       contractOwner,
       uniswapPriceConsumer.address,
-      false
+      false,
+      farmTreasuryAddress,
+      marketTrendKeeperHelper.address
     ],
     log: true,
   });

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,6 +2,7 @@ require("@nomiclabs/hardhat-waffle");
 require("@nomiclabs/hardhat-web3");
 require('hardhat-deploy');
 require('hardhat-deploy-ethers');
+require("hardhat-gas-reporter");
 
 require('dotenv').config();
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "hardhat": "^2.5.0",
     "hardhat-deploy": "^0.9.1",
     "hardhat-deploy-ethers": "^0.3.0-beta.10",
+    "hardhat-gas-reporter": "^1.0.4",
     "web3": "^1.5.2"
   }
 }


### PR DESCRIPTION
implement keeper

reduce gas costs on market trend tracker

before, after gas estimation

![Screenshot from 2021-11-06 10-20-25](https://user-images.githubusercontent.com/22310470/140612976-bd5dee1c-20b7-4383-af5c-c7f638ca6202.png)

![Screenshot from 2021-11-06 10-20-55](https://user-images.githubusercontent.com/22310470/140612975-ead99b2e-6a88-41f8-aa4f-23942c5d7489.png)


sum of avgs: 
before = 591361
after = 554587
